### PR TITLE
VNC proper loading

### DIFF
--- a/manager/manager/vnc/vnc_server.py
+++ b/manager/manager/vnc/vnc_server.py
@@ -57,6 +57,7 @@ class Vnc_server:
         self.running = True
 
         self.wait_for_port("localhost", internal_port)
+        self.wait_for_port("localhost", external_port)
 
         self.create_desktop_icon()
         self.create_gzclient_icon()


### PR DESCRIPTION
I have added a blocking check that prevents the visualization-ready message of being sent until the VNC server are already running. 