### PR TITLE
Custom universes

### DIFF
--- a/manager/manager/launcher/launcher_visualization.py
+++ b/manager/manager/launcher/launcher_visualization.py
@@ -18,6 +18,24 @@ visualization = {
             "internal_port": 5901,
         }
     ],
+    "bt_studio": [
+        {
+            "type": "module",
+            "module": "console",
+            "display": ":1",
+            "external_port": 1108,
+            "internal_port": 5901,
+        },
+        {
+            "type": "module",
+            "width": 1024,
+            "height": 768,
+            "module": "gazebo_view",
+            "display": ":2",
+            "external_port": 6080,
+            "internal_port": 5900,
+        },
+    ],
     "gazebo_gra": [
         {
             "type": "module",

--- a/manager/manager/manager.py
+++ b/manager/manager/manager.py
@@ -217,7 +217,7 @@ class Manager:
 
         self.world_launcher = LauncherWorld(**cfg.model_dump())
         LogManager.logger.info(str(self.world_launcher))
-        self.world_launcher.run()   
+        self.world_launcher.run()
         LogManager.logger.info("Launch transition finished")
 
     def prepare_custom_universe(self, cfg_dict):
@@ -386,8 +386,9 @@ ideal_cycle = 20
     def on_terminate_visualization(self, event):
 
         self.visualization_launcher.terminate()
-        self.gui_server.stop()
-        self.gui_server = None
+        if self.gui_server != None:
+            self.gui_server.stop()
+            self.gui_server = None
 
     def on_terminate_universe(self, event):
 

--- a/manager/manager/manager.py
+++ b/manager/manager/manager.py
@@ -206,10 +206,10 @@ class Manager:
             cfg_dict = event.kwargs.get("data", {})
             cfg = ConfigurationManager.validate(cfg_dict)
             if "zip" in cfg_dict:
-                LogManager.logger.info("There is a zip in the msg!")
+                LogManager.logger.info("Launching universe from received zip")
                 self.prepare_custom_universe(cfg_dict)
             else:
-                LogManager.logger.info("Normal, no zip")
+                LogManager.logger.info("Launching universe from the RB")
 
             LogManager.logger.info(cfg)
         except ValueError as e:
@@ -217,22 +217,22 @@ class Manager:
 
         self.world_launcher = LauncherWorld(**cfg.model_dump())
         LogManager.logger.info(str(self.world_launcher))
-        self.world_launcher.run()
+        self.world_launcher.run()   
         LogManager.logger.info("Launch transition finished")
 
     def prepare_custom_universe(self, cfg_dict):
-        print("Custom universe")
 
         # Unzip the app
         if cfg_dict["zip"].startswith("data:"):
             _, _, zip_file = cfg_dict["zip"].partition("base64,")
 
-        zip_destination = "/workspace/worlds/" + cfg_dict["name"] + ".zip"
+        universe_ref = "/workspace/worlds/" + cfg_dict["name"]
+        zip_destination = universe_ref + ".zip"
         with open(zip_destination, "wb") as result:
             result.write(base64.b64decode(zip_file))
 
         # Create the folder if it doesn't exist
-        universe_folder = "/workspace/worlds/" + cfg_dict["name"] + "/"
+        universe_folder = universe_ref + "/"
         if not os.path.exists(universe_folder):
             os.makedirs(universe_folder)
 
@@ -241,6 +241,7 @@ class Manager:
         zip_ref.close()
 
     def on_prepare_visualization(self, event):
+
         LogManager.logger.info("Visualization transition started")
 
         visualization_type = event.kwargs.get("data", {})
@@ -252,6 +253,7 @@ class Manager:
         if visualization_type == "gazebo_rae":
             self.gui_server = Server(2303, self.update)
             self.gui_server.start()
+
         LogManager.logger.info("Visualization transition finished")
 
     def add_frequency_control(self, code):


### PR DESCRIPTION
This allows the RB to run custom universes send as a zip. When the launchWorld() function is invoked, the RAM now checks for the "zip" field, decompress its content in /workspace/worlds and launchs the universe as usual. Example config:

```
universe_cfg = {
    name: name,
    launch_file_path: /workspace/worlds/name/launch.py,
    ros_version: ros_version,
    world: world,
    zip: base64data,
};
```

The disposition of the files within the zip is up to the user, but it must take into account for the moment the resulting path for the decompressed launcher