### PR TITLE
Fixed console debug

### DIFF
--- a/manager/manager/manager.py
+++ b/manager/manager/manager.py
@@ -289,20 +289,20 @@ ideal_cycle = 20
         def find_docker_console():
             """Search console in docker different of /dev/pts/0"""
             pts_consoles = [f"/dev/pts/{dev}" for dev in os.listdir('/dev/pts/') if dev.isdigit()]
-            
+            consoles = []
             for console in pts_consoles:
                 if console != "/dev/pts/0":
                     try:
                         # Search if it's a console
                         with open(console, 'w') as f:
                             f.write("")
-                        return console
+                        consoles.append(console)
                     except Exception:
                         # Continue searching
                         continue
             
-            raise Exception("No active console other than /dev/pts/0")
-
+            # raise Exception("No active console other than /dev/pts/0")
+            return consoles
 
         code_path = "/workspace/code/exercise.py"
         # Extract app config
@@ -350,10 +350,9 @@ ideal_cycle = 20
             self.unpause_sim()
         else:
             console_path = find_docker_console()
-            # print(f"Consola encontrada: {console_path}")
-
-            with open(console_path, 'w') as console:
-                console.write(errors + "\n\n")
+            for i in console_path:
+                with open(i, 'w') as console:
+                    console.write(errors + "\n\n")
 
             raise Exception(errors)
 

--- a/manager/manager/manager.py
+++ b/manager/manager/manager.py
@@ -331,7 +331,18 @@ ideal_cycle = 20
             )
             self.unpause_sim()
         else:
-            with open('/dev/pts/1', 'w') as console:
+            # Temporal solution
+            # TODO: Need to check console pty num after launching the console and then pass the error to that pty
+            # Right now, it just send error description to the last pty at /dev/pts/. If user opens a new console (access docker through terminal),
+            # then this solution stops working
+            check_pty = ['ls', '/dev/pts/']
+            proc = subprocess.Popen(check_pty, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            o, e = proc.communicate()
+            print('Output: ' + o.decode('ascii'))
+            result = ''.join(c for c in o.decode('ascii') if c.isdigit())
+            devNum = result[-1]
+
+            with open('/dev/pts/' + devNum, 'w') as console:
                 console.write(errors + "\n\n")
 
             raise Exception(errors)


### PR DESCRIPTION
Creates a temporal fix that will display error on any exercise. This works beacuse the teminal is the last one pty to start, is case a user creates another pty (connects to the docker container using a terminal), this solution stop working.

Its necessary to save the /dev/pts/ number of the console after its started, and then pass it to the manager so it can always send the error description to the correct pty (the one that is showed to the user in the browser)