### PR TITLE
Avoid setting default DRI_NAME variable blindly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Byte-compiled file
 __pycache__/
 /.idea
+
+# IDEs
+.vscode

--- a/manager/manager/launcher/launcher_console.py
+++ b/manager/manager/launcher/launcher_console.py
@@ -16,7 +16,7 @@ class LauncherConsole(ILauncher):
     console_vnc: Any = Vnc_server()
 
     def run(self, callback):
-        DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
+        DRI_PATH = self.get_dri_path()
         ACCELERATION_ENABLED = False
 
         if ACCELERATION_ENABLED:
@@ -37,12 +37,6 @@ class LauncherConsole(ILauncher):
         self.threads.append(console_thread)
 
         self.running = True
-
-    def check_device(self, device_path):
-        try:
-            return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
-        except:
-            return False
 
     def is_running(self):
         return self.running

--- a/manager/manager/launcher/launcher_gazebo_view.py
+++ b/manager/manager/launcher/launcher_gazebo_view.py
@@ -51,12 +51,6 @@ class LauncherGazeboView(ILauncher):
 
         self.running = True
 
-    def check_device(self, device_path):
-        try:
-            return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
-        except:
-            return False
-
     def is_running(self):
         return self.running
 
@@ -71,14 +65,3 @@ class LauncherGazeboView(ILauncher):
 
     def died(self):
         pass
-
-    def get_dri_path(self):
-        directory_path = "/dev/dri"
-        dri_path = ""
-        if os.path.exists(directory_path) and os.path.isdir(directory_path):
-            files = os.listdir(directory_path)
-            if "card1" in files:
-                dri_path = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card1"))
-            else:
-                dri_path = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
-        return dri_path

--- a/manager/manager/launcher/launcher_interface.py
+++ b/manager/manager/launcher/launcher_interface.py
@@ -1,3 +1,6 @@
+import os
+import stat
+
 from pydantic import BaseModel
 
 
@@ -17,6 +20,20 @@ class ILauncher(BaseModel):
     def from_config(cls, config):
         obj = cls(**config)
         return obj
+
+    @staticmethod
+    def get_dri_path():
+        # If DRI_NAME is not set, set DRI_PATH to None
+        dri_name = os.environ.get("DRI_NAME")
+        dri_path = os.path.join("/dev/dri", dri_name) if dri_name else None
+        return dri_path
+
+    @staticmethod
+    def check_device(device_path):
+        try:
+            return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
+        except:
+            return False
 
 
 class LauncherException(Exception):

--- a/manager/manager/launcher/launcher_robot_display_view.py
+++ b/manager/manager/launcher/launcher_robot_display_view.py
@@ -16,11 +16,11 @@ class LauncherRobotDisplayView(ILauncher):
     threads = []
 
     def run(self, callback):
-        DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
+        DRI_PATH = self.get_dri_path()
         ACCELERATION_ENABLED = self.check_device(DRI_PATH)
 
         robot_display_vnc = Vnc_server()
-        
+
         if (ACCELERATION_ENABLED):
             robot_display_vnc.start_vnc_gpu(self.display, self.internal_port, self.external_port,DRI_PATH)
             # Write display config and start the console
@@ -34,13 +34,7 @@ class LauncherRobotDisplayView(ILauncher):
         console_thread.start()
         self.threads.append(console_thread)
 
-        self.running = True        
-
-    def check_device(self, device_path):
-        try:
-            return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
-        except:
-            return False
+        self.running = True
 
     def is_running(self):
         return self.running

--- a/manager/manager/launcher/launcher_ros2_api.py
+++ b/manager/manager/launcher/launcher_ros2_api.py
@@ -17,7 +17,7 @@ class LauncherRos2Api(ILauncher):
     threads: List[Any] = []
 
     def run(self, callback):
-        DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
+        DRI_PATH = self.get_dri_path()
         ACCELERATION_ENABLED = self.check_device(DRI_PATH)
 
         logging.getLogger("roslaunch").setLevel(logging.CRITICAL)
@@ -36,12 +36,6 @@ class LauncherRos2Api(ILauncher):
 
         exercise_launch_thread = DockerThread(exercise_launch_cmd)
         exercise_launch_thread.start()
-
-    def check_device(self, device_path):
-        try:
-            return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
-        except:
-            return False
 
     def terminate(self):
         if self.threads is not None:

--- a/manager/manager/launcher/launcher_rviz_ros2.py
+++ b/manager/manager/launcher/launcher_rviz_ros2.py
@@ -12,7 +12,7 @@ class LauncherRvizRos2(ILauncher):
     threads = []
 
     def run(self, callback):
-        DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
+        DRI_PATH = self.get_dri_path()
         ACCELERATION_ENABLED = self.check_device(DRI_PATH)
         rviz_vnc = Vnc_server()
 
@@ -27,12 +27,6 @@ class LauncherRvizRos2(ILauncher):
         rviz_thread.start()
         self.threads.append(rviz_thread)
         self.running = True
-
-    def check_device(self, device_path):
-        try:
-            return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
-        except:
-            return False
 
     def is_running(self):
         return self.running

--- a/manager/manager/launcher/launcher_teleoperator_ros2.py
+++ b/manager/manager/launcher/launcher_teleoperator_ros2.py
@@ -10,9 +10,9 @@ class LauncherTeleoperatorRos2(ILauncher):
     threads = []
 
     def run(self, callback):
-        DRI_PATH = os.path.join("/dev/dri", os.environ.get("DRI_NAME", "card0"))
+        DRI_PATH = self.get_dri_path()
         ACCELERATION_ENABLED = self.check_device(DRI_PATH)
-        
+
         if (ACCELERATION_ENABLED):
             teleop_cmd = f"export VGL_DISPLAY={DRI_PATH}; vglrun python3 /opt/jderobot/utils/model_teleoperator.py 0.0.0.0"
         else:
@@ -23,12 +23,6 @@ class LauncherTeleoperatorRos2(ILauncher):
         self.threads.append(teleop_thread)
 
         self.running = True
-    
-    def check_device(self, device_path):
-        try:
-            return stat.S_ISCHR(os.lstat(device_path)[stat.ST_MODE])
-        except:
-            return False
 
     def is_running(self):
         return self.running


### PR DESCRIPTION
Only the `set_dri_name.sh` script (https://github.com/JdeRobot/RoboticsInfrastructure/pull/442) should be in charge of finding a valid GPU for acceleration. Setting `card0` by default when `DRI_NAME` is not defined can be problematic if said card exists but its drivers are not valid (e.g. there is a nvidia card in said direction but the drivers are not working within the container).

Besides, this PR reduces the redundancy found in the launchers by moving to `manager/manager/launcher/launcher_interface.py` the functions for building `DRI_PATH` and checking if its valid.