### PR TITLE
fix(vnc): increase VNC and XServer timeouts for macOS/ARM64

### DIFF
--- a/manager/libs/applications/compatibility/server.py
+++ b/manager/libs/applications/compatibility/server.py
@@ -14,7 +14,7 @@ class Server(threading.Thread):
     ):
         super().__init__()
         self.update_callback = callback
-        self.server = WebsocketServer(port=port, host="127.0.0.1")
+        self.server = WebsocketServer(port=port, host="0.0.0.0")
         self.server.set_fn_new_client(self.on_open)
         self.server.set_fn_client_left(self.on_close)
         self.server.set_fn_message_received(self.on_message)

--- a/manager/libs/applications/compatibility/server.py
+++ b/manager/libs/applications/compatibility/server.py
@@ -14,7 +14,7 @@ class Server(threading.Thread):
     ):
         super().__init__()
         self.update_callback = callback
-        self.server = WebsocketServer(port=port, host="0.0.0.0")
+        self.server = WebsocketServer(port=port, host="127.0.0.1")
         self.server.set_fn_new_client(self.on_open)
         self.server.set_fn_client_left(self.on_close)
         self.server.set_fn_message_received(self.on_message)

--- a/manager/libs/process_utils.py
+++ b/manager/libs/process_utils.py
@@ -75,7 +75,7 @@ def is_xserver_running(display):
     return os.path.exists(x_socket_path)
 
 
-def wait_for_xserver(display, timeout=30):
+def wait_for_xserver(display, timeout=120):
     """
     Wait for the X server to start within a specified timeout period.
 

--- a/manager/manager/vnc/vnc_server.py
+++ b/manager/manager/vnc/vnc_server.py
@@ -115,13 +115,13 @@ class Vnc_server:
         self.wait_for_port("localhost", internal_port)
         self.wait_for_port("localhost", external_port)
 
-    def wait_for_port(self, host, port, timeout=20):
+    def wait_for_port(self, host, port, timeout=120):
         """Wait for a TCP port on a host to become available within a timeout period.
 
         Args:
             host (str): Hostname or IP address to check.
             port (int): Port number to check.
-            timeout (int, optional): Maximum time to wait in seconds. Defaults to 20.
+            timeout (int, optional): Maximum time to wait in seconds. Defaults to 120.
 
         Raises:
             TimeoutError: If the port does not become available within the timeout.


### PR DESCRIPTION
hi @jmplaza @javizqh 
this pr address the stability issue, preventing the robotics acadamy from starting on mac os with apple silicon (m1,m2,m3),

for all these devices, the docker container runs under QEMU Emulation which introduces significant performance overhead around 10 times slower than naive x86 and the current hardcoded timeouts are insufficnent for this environment.

As the result the application continously crashes with TimeoutError, before the simulation can finish loading
<img width="1026" height="642" alt="Screenshot 2026-02-13 at 6 31 08 PM" src="https://github.com/user-attachments/assets/76a9fc47-9024-48de-86c1-e6a308ef8fa2" />

to solve this, i have increased the timeout to accomodate the emulation overload
1) vnc_server.py --- increased to 120 sec
2) process_utils.py---- increased by 120 sec

this works reliabely on macos ans has no negative impact on native Linux users.

